### PR TITLE
fix off-by-one error in random number generation

### DIFF
--- a/stream_sampler.rb
+++ b/stream_sampler.rb
@@ -18,7 +18,7 @@ module StreamSampler
       if idx < n
         out << i
       else
-        j = rand(idx) 
+        j = rand(idx + 1) 
         out[j] = i if j < n
       end
     end


### PR DESCRIPTION
subtle bug: the range of the emitted random number will be wrong unless it starts from 1.
